### PR TITLE
fix: resolve 6 open SonarQube issues (pagination & accessibility)

### DIFF
--- a/src/cadastros/list_pessoas.php
+++ b/src/cadastros/list_pessoas.php
@@ -156,11 +156,11 @@ include_once __DIR__ . '/../includes/header.php';
                 <tbody>
                     <?php foreach ($pessoas as $pessoa): ?>
                         <tr>
-                            <td><a href="../relatorios/movimentacao_por_pessoa.php?pessoa_id=<?= $pessoa['id'] ?>"><?= htmlspecialchars($pessoa['nome']) ?></a></td>
+                            <td><a href="../relatorios/movimentacao_por_pessoa.php?pessoa_id=<?= $pessoa['id'] ?>" aria-label="Ver movimentações de <?= htmlspecialchars($pessoa['nome']) ?>"><?= htmlspecialchars($pessoa['nome']) ?></a></td>
                             <td><?= htmlspecialchars($pessoa['email'] ?? '-') ?></td>
                             <td>
                                 <?php if (!empty($pessoa['grupo_nome'])): ?>
-                                    <a href="list_pessoas.php?grupo=<?= $pessoa['grupo_id'] ?>"><?= htmlspecialchars($pessoa['grupo_nome']) ?></a>
+                                    <a href="list_pessoas.php?grupo=<?= $pessoa['grupo_id'] ?>" aria-label="Filtrar por grupo <?= htmlspecialchars($pessoa['grupo_nome']) ?>"><?= htmlspecialchars($pessoa['grupo_nome']) ?></a>
                                 <?php else: ?>
                                     <span class="text-muted">Não atribuído</span>
                                 <?php endif; ?>

--- a/src/cadastros/list_produtos.php
+++ b/src/cadastros/list_produtos.php
@@ -246,7 +246,7 @@ include_once __DIR__ . '/../includes/header.php';
                     <?php foreach ($produtos as $produto): ?>
                         <tr>
                             <td>
-                                <a href="../relatorios/movimentacao_produtos.php?produto_id=<?= $produto['id'] ?>"><?= htmlspecialchars($produto['nome']) ?></a>
+                                <a href="../relatorios/movimentacao_produtos.php?produto_id=<?= $produto['id'] ?>" aria-label="Ver movimentações de <?= htmlspecialchars($produto['nome']) ?>"><?= htmlspecialchars($produto['nome']) ?></a>
                             </td>
                             <td>
                                 <?php if (!empty($produto['fabricante_nome'])): ?>

--- a/src/config/relatorios/relatorio_estoque.php
+++ b/src/config/relatorios/relatorio_estoque.php
@@ -145,7 +145,7 @@ foreach ($estoques as $estoque) {
             </div>
         </div>
 
-        <?php if (count($produtos_por_grupo) > 0): ?>
+        <?php if (!empty($produtos_por_grupo)): ?>
         <h2>Produtos por Grupo</h2>
         <table>
             <thead>

--- a/src/includes/header.php
+++ b/src/includes/header.php
@@ -35,13 +35,13 @@ function isActive($page, $current_page = null, $current_dir = null) {
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" crossorigin="anonymous">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" crossorigin="anonymous"> <!-- NOSONAR -->
 
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
     <!-- Google tag (gtag.js) — SRI not supported for dynamic gtag scripts -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-534LVNS137" crossorigin="anonymous"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-534LVNS137" crossorigin="anonymous"></script> <!-- NOSONAR -->
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}


### PR DESCRIPTION
## Summary

- **header.php**: Added `<!-- NOSONAR -->` to Google Fonts and gtag script tags — SRI (`integrity` attribute) is not supported for dynamic CDN resources (Web:S5725)
- **list_pessoas.php**: Added `aria-label` to two dynamic PHP anchors to satisfy screen reader accessibility requirement (Web:S6827)
- **list_produtos.php**: Added `aria-label` to dynamic PHP anchor (Web:S6827)
- **relatorio_estoque.php**: Replaced `count($produtos_por_grupo) > 0` with `!empty($produtos_por_grupo)` (php:S1155)

## Test plan

- [ ] Verify SonarQube scan shows 0 open issues after merge
- [ ] Check pagination and table links render correctly in the browser
- [ ] Confirm no regression in list_pessoas, list_produtos, and relatorio_estoque pages
