### PR TITLE
Replace include with include_once for pagination and summary includes

### DIFF
--- a/src/cadastros/list_fabricantes.php
+++ b/src/cadastros/list_fabricantes.php
@@ -140,7 +140,7 @@ include_once __DIR__ . '/../includes/header.php';
 
         <?php
         $pagination_extra = !empty($search) ? '&search=' . urlencode($search) : '';
-        include __DIR__ . '/../includes/pagination.php';
+        include_once __DIR__ . '/../includes/pagination.php';
         ?>
     <?php else: ?>
         <div class="alert alert-info">

--- a/src/cadastros/list_grupos.php
+++ b/src/cadastros/list_grupos.php
@@ -152,7 +152,7 @@ include_once __DIR__ . '/../includes/header.php';
 
         <?php
         $pagination_extra = !empty($search) ? '&search=' . urlencode($search) : '';
-        include __DIR__ . '/../includes/pagination.php';
+        include_once __DIR__ . '/../includes/pagination.php';
         ?>
     <?php else: ?>
         <div class="alert alert-info">

--- a/src/cadastros/list_grupos_pessoas.php
+++ b/src/cadastros/list_grupos_pessoas.php
@@ -135,7 +135,7 @@ include_once __DIR__ . '/../includes/header.php';
 
         <?php
         $pagination_extra = !empty($search) ? '&search=' . urlencode($search) : '';
-        include __DIR__ . '/../includes/pagination.php';
+        include_once __DIR__ . '/../includes/pagination.php';
         ?>
     <?php else: ?>
         <div class="alert alert-info">

--- a/src/cadastros/list_lugares.php
+++ b/src/cadastros/list_lugares.php
@@ -119,7 +119,7 @@ include_once __DIR__ . '/../includes/header.php';
 
         <?php
         $pagination_extra = !empty($search) ? '&search=' . urlencode($search) : '';
-        include __DIR__ . '/../includes/pagination.php';
+        include_once __DIR__ . '/../includes/pagination.php';
         ?>
     <?php else: ?>
         <div class="alert alert-info">

--- a/src/cadastros/list_pessoas.php
+++ b/src/cadastros/list_pessoas.php
@@ -197,7 +197,7 @@ include_once __DIR__ . '/../includes/header.php';
         <?php
         $pagination_extra = (!empty($search) ? '&search=' . urlencode($search) : '')
                           . ($filter_grupo ? '&grupo=' . $filter_grupo : '');
-        include __DIR__ . '/../includes/pagination.php';
+        include_once __DIR__ . '/../includes/pagination.php';
         ?>
     <?php else: ?>
         <div class="alert alert-info">

--- a/src/cadastros/list_produtos.php
+++ b/src/cadastros/list_produtos.php
@@ -303,7 +303,7 @@ include_once __DIR__ . '/../includes/header.php';
         if (!empty($filter_tipo)) { $pagination_params[] = 'tipo=' . urlencode($filter_tipo); }
         if (!empty($search)) { $pagination_params[] = 'search=' . urlencode($search); }
         $pagination_extra = !empty($pagination_params) ? '&' . implode('&', $pagination_params) : '';
-        include __DIR__ . '/../includes/pagination.php';
+        include_once __DIR__ . '/../includes/pagination.php';
         ?>
     <?php else: ?>
         <div class="alert alert-info">

--- a/src/relatorios/movimentacao_por_almoxarifado.php
+++ b/src/relatorios/movimentacao_por_almoxarifado.php
@@ -159,7 +159,7 @@ include_once __DIR__ . '/../includes/header.php';
         </div>
 
         <br>
-        <?php include __DIR__ . '/../includes/movimento_summary_cards.php'; ?>
+        <?php include_once __DIR__ . '/../includes/movimento_summary_cards.php'; ?>
 
         <br>
         <?php if (!empty($produtos_movimentados)): ?>

--- a/src/relatorios/movimentacao_por_pessoa.php
+++ b/src/relatorios/movimentacao_por_pessoa.php
@@ -182,7 +182,7 @@ include_once __DIR__ . '/../includes/header.php';
         </div>
 
         <br>
-        <?php include __DIR__ . '/../includes/movimento_summary_cards.php'; ?>
+        <?php include_once __DIR__ . '/../includes/movimento_summary_cards.php'; ?>
 
         <br>
         <?php if (!empty($movimentos)): ?>


### PR DESCRIPTION
## Summary
This PR updates file inclusion statements to use `include_once` instead of `include` for pagination and summary card components, preventing issues caused by multiple inclusions of the same file.

## Key Changes
- **List pages** (`list_fabricantes.php`, `list_grupos.php`, `list_grupos_pessoas.php`, `list_lugares.php`, `list_pessoas.php`, `list_produtos.php`): Replaced `include` with `include_once` for `pagination.php`.
- **Report pages** (`movimentacao_por_almoxarifado.php`, `movimentacao_por_pessoa.php`): Replaced `include` with `include_once` for `movimento_summary_cards.php`.

## Implementation Details
Using `include_once` ensures that shared components are loaded only once per request, avoiding duplicate code execution and potential variable redefinition. This aligns with best practices for including reusable template files that may be referenced from multiple code paths.