### PR TITLE
fix: suppress SonarQube Web:S5725 for header.php

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,14 +1,15 @@
 sonar.projectKey=siproquim
 sonar.organization=gmedeirosnet
 
-
-# This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=SIPROQUIM
-#sonar.projectVersion=1.0
 
-
-# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=.
 
-# Encoding of the source code. Default is default system encoding
-#sonar.sourceEncoding=UTF-8
+sonar.sourceEncoding=UTF-8
+
+# Suppress Web:S5725 (missing SRI integrity attribute) for header.php.
+# Google Fonts and Google Analytics do not publish static SRI hashes —
+# the resources are dynamically served and cannot be pinned with integrity.
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=Web:S5725
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/header.php


### PR DESCRIPTION
## Summary

- Add `sonar.issue.ignore.multicriteria` to `sonar-project.properties` to suppress `Web:S5725` (missing SRI `integrity` attribute) for `src/includes/header.php`.
- `<!-- NOSONAR -->` comments were already present, but SonarQube Web rules do not support inline suppression; a project-level exclusion is the correct mechanism.
- Google Fonts and Google Analytics (`gtag.js`) do not provide static SRI hashes; their resources are dynamically served and cannot be safely pinned with `integrity` attributes.

## Test plan

- [ ] Run a SonarQube scan and verify that it reports 0 open issues after the merge.
- [ ] Confirm that the Quality Gate remains green.